### PR TITLE
연혁 데이터 좌/우 배치 및 기타 작업

### DIFF
--- a/history.css
+++ b/history.css
@@ -25,25 +25,16 @@ body {
 }
 
 .historyCard {
-    width: 50%;
-    /* border: 1px solid black; */
-}
-
-.historyCard::after {
-    content: "";
-    display: block;
-    flex-basis: clac(50% - 2px);
-    border: 2px solid red;
-    height: 100%;
-    position: absolute;
-    left: 50%;
+    box-sizing: border-box; /* 핵심: 박스 사이즈가 테두리를 포함! */
+    flex: 50%; /* 각 요소가 50%씩 차지 */
+    position: relative;
+    padding: 20px;
 }
 
 .historyCard:nth-child(odd) {
-    flex-grow: 1;
-
+    border-right: 2px solid red;
 }
 
 .historyCard:nth-child(even) {
-    flex-grow: 2;
+    border-left: 2px solid red;
 }

--- a/history.css
+++ b/history.css
@@ -1,13 +1,13 @@
-*{
+* {
     margin: 0;
     padding: 0;
 }
 
-body{
+body {
     overflow-x: hidden;
 }
 
-.wrapper{
+.wrapper {
     width: 100vw;
     height: 100vh;
 }
@@ -17,19 +17,19 @@ body{
     font-size: 16px;
 }
 
-.history{
+.history {
     display: flex;
     flex-flow: row wrap;
     width: 100vw;
     height: 100vh;
 }
 
-.historyCard{
+.historyCard {
     width: 50%;
     /* border: 1px solid black; */
 }
 
-.historyCard::after{
+.historyCard::after {
     content: "";
     display: block;
     flex-basis: clac(50% - 2px);
@@ -39,11 +39,11 @@ body{
     left: 50%;
 }
 
-.historyCard:nth-child(odd){
+.historyCard:nth-child(odd) {
     flex-grow: 1;
-    
+
 }
 
-.historyCard:nth-child(even){
+.historyCard:nth-child(even) {
     flex-grow: 2;
 }

--- a/history.js
+++ b/history.js
@@ -1,7 +1,6 @@
-import historyList from "./history.json" assert{type: "json"};
-
-// drawHistory();
-drawHistory();
+window.onload = function() {
+    drawHistory();
+}
 
 function drawHistory() {
     let historyBox = document.getElementById("historyGridView");

--- a/history.js
+++ b/history.js
@@ -8,17 +8,15 @@ function drawHistory() {
     for (let i = 0; i < historyList.totalhistory.length; i++) {
         let historyCard = document.createElement("div");
         let year = document.createElement("div");
-        let historyDesc = document.createElement("div");
 
         const currentHistory = historyList.totalhistory[i];
 
         historyCard.className = "historyCard";
         year.className = "historyYear";
-        historyDesc.className = "historyDesc";
         year.textContent = currentHistory.year;
 
         historyBox.append(historyCard);
-        historyCard.append(year, historyDesc);
+        historyCard.append(year);
         console.log(currentHistory);
 
         for (let j = 0; j < currentHistory.history.length; j++) {

--- a/history.js
+++ b/history.js
@@ -1,28 +1,28 @@
-import historyList from "./history.json" assert{type:"json"};
+import historyList from "./history.json" assert{type: "json"};
 
 // drawHistory();
 drawHistory();
 
-function drawHistory(){
+function drawHistory() {
     let historyBox = document.getElementById("historyGridView");
-    
-    for(let i = 0; i < historyList.totalhistory.length; i++){
+
+    for (let i = 0; i < historyList.totalhistory.length; i++) {
         let historyCard = document.createElement("div");
         let year = document.createElement("div");
         let historyDesc = document.createElement("div");
-        
+
         const currentHistory = historyList.totalhistory[i];
-        
+
         historyCard.className = "historyCard";
         year.className = "historyYear";
         historyDesc.className = "historyDesc";
         year.textContent = currentHistory.year;
-        
+
         historyBox.append(historyCard);
         historyCard.append(year, historyDesc);
         console.log(currentHistory);
-        
-        for(let j = 0; j < currentHistory.history.length; j++){
+
+        for (let j = 0; j < currentHistory.history.length; j++) {
             let description = document.createElement("li");
             description.textContent = currentHistory.history[j];
             historyCard.appendChild(description);

--- a/historyList.js
+++ b/historyList.js
@@ -1,4 +1,4 @@
-{
+const historyList = {
     "totalhistory": [
         {
             "year": 2013,

--- a/introduce.html
+++ b/introduce.html
@@ -6,7 +6,8 @@
         <link type="text/css" rel="stylesheet" href="style.css">
         <link type="text/css" rel="stylesheet" href="history.css">
         <script src="nav.js"></script>
-        <script src="history.js" type="module"></script>
+        <script src="historyList.js"></script>
+        <script src="history.js"></script>
     </head>
     <body>
     <div class="wrapper">

--- a/introduce.html
+++ b/introduce.html
@@ -16,9 +16,6 @@
             <div class="history" id="historyGridView">
             </div>
         </main>
-        <div class="test">
-            
-        </div>
     </div>
     </body>
 </html>

--- a/nav.js
+++ b/nav.js
@@ -22,7 +22,7 @@ const headerNavContent = `
     </div>
 `;
 
-window.onload = function(){
+window.onload = function () {
     const headerNav = document.getElementById("headerNav");
     headerNav.innerHTML = headerNavContent;
 }

--- a/player.css
+++ b/player.css
@@ -1,12 +1,12 @@
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500&family=Oleo+Script&family=Open+Sans:wght@400;700&family=Roboto:wght@400;700;900&display=swap%27');
 
-*{
-    margin : 0;
+* {
+    margin: 0;
     padding: 0;
     font-family: 'Noto Sans KR';
 }
 
-.subNav{
+.subNav {
     background: url("media/playerBanner.png") no-repeat center center;
     opacity: 80%;
     height: 500px;
@@ -19,18 +19,18 @@
     align-items: flex-end;
 }
 
-.subNav ul{
+.subNav ul {
     align-items: flex-end;
     text-align: center;
     margin: 0;
     padding: 0;
     width: 100vw;
     height: 40px;
-    background-color:red;
+    background-color: red;
     opacity: 50%;
 }
 
-.subNav li{
+.subNav li {
     list-style: none;
     margin: 0 50px;
     display: inline-flex;
@@ -40,11 +40,11 @@
     font-size: 20px;
 }
 
-.subNav li:hover{
+.subNav li:hover {
     border-bottom: chartreuse;
 }
 
-.subNav a{
+.subNav a {
     align-items: center;
     text-decoration: none;
     color: white;
@@ -53,7 +53,7 @@
     line-height: 40px;
 }
 
-.playerGridContainer{
+.playerGridContainer {
     width: 100vw;
     display: flex;
     /* flex-flow: row wrap; */
@@ -65,39 +65,39 @@
     overflow: hidden;
 }
 
-.playerGridView ul{
+.playerGridView ul {
     align-self: auto;
 }
 
-.playerGridView li{
+.playerGridView li {
     list-style: none;
     display: inline-block;
     margin: 20px;
 }
 
-.playerGridView img{
+.playerGridView img {
     border: 1px solid lightgray;
 }
 
-.playerInfo{
+.playerInfo {
     display: block;
 }
 
-.playerBacknum{
-    float : left;
+.playerBacknum {
+    float: left;
     color: #ec0a0b;
     font-weight: bold;
     font-size: 16px;
 }
 
-.playerName{
+.playerName {
     float: right;
     color: #222;
     font-weight: bold;
     font-size: 16px;
 }
 
-.postionTitle{
+.postionTitle {
     height: 100px;
     width: 100vw;
     background-color: #222;

--- a/player.html
+++ b/player.html
@@ -6,7 +6,8 @@
         <link type="text/css" rel="stylesheet" href="style.css">
         <link type="text/css" rel="stylesheet" href="player.css">
         <script src="nav.js"></script>
-        <script src="playerList.js" type="module"></script>
+        <script src="playerData.js"></script>
+        <script src="playerList.js"></script>
     </head>
     <body>
         <header id="headerNav"></header>

--- a/playerData.js
+++ b/playerData.js
@@ -1,4 +1,4 @@
-{
+const playerList = {
     "pitcher": [
         {
             "position": "투수",

--- a/playerData.json
+++ b/playerData.json
@@ -1,650 +1,650 @@
 {
     "pitcher": [
-      {
-        "position": "투수",
-        "nameKr": "고영표",
-        "backNum": "NO. 1",
-        "birth": "1991-09-16",
-        "physical": "187cm, 88kg",
-        "career": "광주대성초-광주동성중-화순고-동국대-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64001_2023-03-20_103123.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "김건웅",
-        "backNum": "NO. 49",
-        "birth": "2004-04-12",
-        "physical": "187cm, 90kg",
-        "career": "수원영화초-성남중-성남고-KT",
-        "bt": "좌투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/53049_2023-03-20_102726.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "김민",
-        "backNum": "NO. 11",
-        "birth": "1999-04-14",
-        "physical": "185cm, 88kg",
-        "career": "인천숭의초-평촌중-유신고-KT-상무-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68043_2023-03-20_103738.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "김민수",
-        "backNum": "NO. 26",
-        "birth": "1992-07-24",
-        "physical": "188cm, 80kg",
-        "career": "청원초-청원중-청원고-성균관대-KT-상무-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/65048_2023-03-20_103342.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "김영현",
-        "backNum": "NO. 48",
-        "birth": "2002-08-18",
-        "physical": "178cm, 81kg",
-        "career": "광주화정초-광주동성중-광주동성고-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/51097_2023-03-20_102027.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "김재윤",
-        "backNum": "NO. 62",
-        "birth": "1990-09-16",
-        "physical": "185cm, 91kg",
-        "career": "서울도곡초-휘문중-휘문고-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/65062_2023-03-20_103421.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "김정운",
-        "backNum": "NO. 29",
-        "birth": "2004-04-21",
-        "physical": "184cm, 84kg",
-        "career": "동천초-경주중-대구고-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/53029_2023-03-20_102636.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "김태오",
-        "backNum": "NO. 20",
-        "birth": "1997-07-29",
-        "physical": "183cm, 84kg",
-        "career": "연현초-양천중-서울고-KT-상무-KT",
-        "bt": "좌투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/66064_2023-03-20_103455.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "박선우",
-        "backNum": "NO. 45",
-        "birth": "1997-07-12",
-        "physical": "188cm, 91kg",
-        "career": "용마초-창원신월중-부산고-롯데-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/66556_2023-03-20_103508.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "박세진",
-        "backNum": "NO. 47",
-        "birth": "1997-06-27",
-        "physical": "178cm, 93kg",
-        "career": "본리초-경운중-경북고-KT",
-        "bt": "좌투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/66047_2023-03-20_103443.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "박시영",
-        "backNum": "NO. 46",
-        "birth": "1989-03-10",
-        "physical": "180cm, 88kg",
-        "career": "축현초-인천신흥중-제물포고-(영남사이버대)-롯데-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/60559_2023-03-20_103025.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "박영현",
-        "backNum": "NO. 60",
-        "birth": "2003-10-11",
-        "physical": "183cm, 91kg",
-        "career": "부천북초-부천중-유신고-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/52060_2023-03-20_102311.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "배제성",
-        "backNum": "NO. 19",
-        "birth": "1996-09-29",
-        "physical": "189cm, 85kg",
-        "career": "백마초-성남중-성남고-롯데-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/65516_2023-03-20_103432.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "벤자민",
-        "backNum": "NO. 43",
-        "birth": "1993-07-26",
-        "physical": "188cm, 95kg",
-        "career": "미국 Kansas(대)-KT",
-        "bt": "좌투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/52043_2023-03-20_102240.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "소형준",
-        "backNum": "NO. 30",
-        "birth": "2001-09-16",
-        "physical": "189cm, 92kg",
-        "career": "호암초(의정부리틀)-구리인창중-유신고-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/50030_2023-03-20_101730.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "손동현",
-        "backNum": "NO. 41",
-        "birth": "2001-01-23",
-        "physical": "183cm, 88kg",
-        "career": "염창초(강서구리틀)-덕수중-성남고-KT-상무-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/69041_2023-03-20_103927.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "신병률",
-        "backNum": "NO. 15",
-        "birth": "1996-01-30",
-        "physical": "175cm, 83kg",
-        "career": "둔촌초-잠신중-휘문고-단국대-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68067_2023-03-20_103757.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "엄상백",
-        "backNum": "NO. 18",
-        "birth": "1996-10-04",
-        "physical": "187cm, 72kg",
-        "career": "역삼초-언북중-덕수고-KT-상무-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/65056_2023-03-20_103357.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "이상동",
-        "backNum": "NO. 37",
-        "birth": "1995-11-24",
-        "physical": "181cm, 88kg",
-        "career": "대구옥산초-경복중-경북고-영남대-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/69054_2023-06-02_103057.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "이선우",
-        "backNum": "NO. 68",
-        "birth": "2000-09-19",
-        "physical": "186cm, 90kg",
-        "career": "수진초-매송중-유신고-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/69068_2023-03-20_104023.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "이정현",
-        "backNum": "NO. 51",
-        "birth": "1997-12-05",
-        "physical": "188cm, 93kg",
-        "career": "무학초-마산동중-용마고-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/67048_2023-03-20_103632.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "이채호",
-        "backNum": "NO. 17",
-        "birth": "1998-11-23",
-        "physical": "185cm, 85kg",
-        "career": "동광초(김해리틀)-원동중-용마고-SK-SSG-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68896_2023-03-20_103857.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "전용주",
-        "backNum": "NO. 64",
-        "birth": "2000-02-12",
-        "physical": "188cm, 87kg",
-        "career": "양진초(안성시리틀)-성일중-안산공고-KT",
-        "bt": "좌투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/69047_2023-03-20_103944.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "조이현",
-        "backNum": "NO. 54",
-        "birth": "1995-06-27",
-        "physical": "185cm, 95kg",
-        "career": "송정동초-배재중-제주고-한화-SK-상무-SK-SSG-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64768_2023-03-20_103317.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "조현우",
-        "backNum": "NO. 59",
-        "birth": "1994-03-30",
-        "physical": "182cm, 79kg",
-        "career": "군산중앙초-군산중-군산상고-(전남과학대)-KT-롯데-KT",
-        "bt": "좌투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64047_2023-03-20_103237.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "주권",
-        "backNum": "NO. 38",
-        "birth": "1995-05-31",
-        "physical": "181cm, 82kg",
-        "career": "청주우암초-청주중-청주고-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/65060_2023-03-20_103408.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "쿠에바스",
-        "backNum": "NO. 32",
-        "birth": "1990-10-14",
-        "physical": "188cm, 98kg",
-        "career": "베네수엘라 Universidad De Carabobo(대)-KT",
-        "bt": "우투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/69032_2022-02-23_160804.jpg"
-      },
-      {
-        "position": "투수",
-        "nameKr": "하준호",
-        "backNum": "NO. 28",
-        "birth": "1989-04-29",
-        "physical": "174cm, 78kg",
-        "career": "하단초-대동중-경남고-롯데-KT",
-        "bt": "좌투",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/78517_2023-03-20_104118.jpg"
-      }
+        {
+            "position": "투수",
+            "nameKr": "고영표",
+            "backNum": "NO. 1",
+            "birth": "1991-09-16",
+            "physical": "187cm, 88kg",
+            "career": "광주대성초-광주동성중-화순고-동국대-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64001_2023-03-20_103123.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "김건웅",
+            "backNum": "NO. 49",
+            "birth": "2004-04-12",
+            "physical": "187cm, 90kg",
+            "career": "수원영화초-성남중-성남고-KT",
+            "bt": "좌투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/53049_2023-03-20_102726.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "김민",
+            "backNum": "NO. 11",
+            "birth": "1999-04-14",
+            "physical": "185cm, 88kg",
+            "career": "인천숭의초-평촌중-유신고-KT-상무-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68043_2023-03-20_103738.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "김민수",
+            "backNum": "NO. 26",
+            "birth": "1992-07-24",
+            "physical": "188cm, 80kg",
+            "career": "청원초-청원중-청원고-성균관대-KT-상무-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/65048_2023-03-20_103342.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "김영현",
+            "backNum": "NO. 48",
+            "birth": "2002-08-18",
+            "physical": "178cm, 81kg",
+            "career": "광주화정초-광주동성중-광주동성고-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/51097_2023-03-20_102027.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "김재윤",
+            "backNum": "NO. 62",
+            "birth": "1990-09-16",
+            "physical": "185cm, 91kg",
+            "career": "서울도곡초-휘문중-휘문고-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/65062_2023-03-20_103421.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "김정운",
+            "backNum": "NO. 29",
+            "birth": "2004-04-21",
+            "physical": "184cm, 84kg",
+            "career": "동천초-경주중-대구고-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/53029_2023-03-20_102636.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "김태오",
+            "backNum": "NO. 20",
+            "birth": "1997-07-29",
+            "physical": "183cm, 84kg",
+            "career": "연현초-양천중-서울고-KT-상무-KT",
+            "bt": "좌투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/66064_2023-03-20_103455.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "박선우",
+            "backNum": "NO. 45",
+            "birth": "1997-07-12",
+            "physical": "188cm, 91kg",
+            "career": "용마초-창원신월중-부산고-롯데-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/66556_2023-03-20_103508.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "박세진",
+            "backNum": "NO. 47",
+            "birth": "1997-06-27",
+            "physical": "178cm, 93kg",
+            "career": "본리초-경운중-경북고-KT",
+            "bt": "좌투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/66047_2023-03-20_103443.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "박시영",
+            "backNum": "NO. 46",
+            "birth": "1989-03-10",
+            "physical": "180cm, 88kg",
+            "career": "축현초-인천신흥중-제물포고-(영남사이버대)-롯데-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/60559_2023-03-20_103025.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "박영현",
+            "backNum": "NO. 60",
+            "birth": "2003-10-11",
+            "physical": "183cm, 91kg",
+            "career": "부천북초-부천중-유신고-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/52060_2023-03-20_102311.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "배제성",
+            "backNum": "NO. 19",
+            "birth": "1996-09-29",
+            "physical": "189cm, 85kg",
+            "career": "백마초-성남중-성남고-롯데-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/65516_2023-03-20_103432.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "벤자민",
+            "backNum": "NO. 43",
+            "birth": "1993-07-26",
+            "physical": "188cm, 95kg",
+            "career": "미국 Kansas(대)-KT",
+            "bt": "좌투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/52043_2023-03-20_102240.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "소형준",
+            "backNum": "NO. 30",
+            "birth": "2001-09-16",
+            "physical": "189cm, 92kg",
+            "career": "호암초(의정부리틀)-구리인창중-유신고-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/50030_2023-03-20_101730.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "손동현",
+            "backNum": "NO. 41",
+            "birth": "2001-01-23",
+            "physical": "183cm, 88kg",
+            "career": "염창초(강서구리틀)-덕수중-성남고-KT-상무-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/69041_2023-03-20_103927.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "신병률",
+            "backNum": "NO. 15",
+            "birth": "1996-01-30",
+            "physical": "175cm, 83kg",
+            "career": "둔촌초-잠신중-휘문고-단국대-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68067_2023-03-20_103757.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "엄상백",
+            "backNum": "NO. 18",
+            "birth": "1996-10-04",
+            "physical": "187cm, 72kg",
+            "career": "역삼초-언북중-덕수고-KT-상무-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/65056_2023-03-20_103357.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "이상동",
+            "backNum": "NO. 37",
+            "birth": "1995-11-24",
+            "physical": "181cm, 88kg",
+            "career": "대구옥산초-경복중-경북고-영남대-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/69054_2023-06-02_103057.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "이선우",
+            "backNum": "NO. 68",
+            "birth": "2000-09-19",
+            "physical": "186cm, 90kg",
+            "career": "수진초-매송중-유신고-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/69068_2023-03-20_104023.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "이정현",
+            "backNum": "NO. 51",
+            "birth": "1997-12-05",
+            "physical": "188cm, 93kg",
+            "career": "무학초-마산동중-용마고-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/67048_2023-03-20_103632.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "이채호",
+            "backNum": "NO. 17",
+            "birth": "1998-11-23",
+            "physical": "185cm, 85kg",
+            "career": "동광초(김해리틀)-원동중-용마고-SK-SSG-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68896_2023-03-20_103857.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "전용주",
+            "backNum": "NO. 64",
+            "birth": "2000-02-12",
+            "physical": "188cm, 87kg",
+            "career": "양진초(안성시리틀)-성일중-안산공고-KT",
+            "bt": "좌투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/69047_2023-03-20_103944.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "조이현",
+            "backNum": "NO. 54",
+            "birth": "1995-06-27",
+            "physical": "185cm, 95kg",
+            "career": "송정동초-배재중-제주고-한화-SK-상무-SK-SSG-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64768_2023-03-20_103317.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "조현우",
+            "backNum": "NO. 59",
+            "birth": "1994-03-30",
+            "physical": "182cm, 79kg",
+            "career": "군산중앙초-군산중-군산상고-(전남과학대)-KT-롯데-KT",
+            "bt": "좌투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64047_2023-03-20_103237.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "주권",
+            "backNum": "NO. 38",
+            "birth": "1995-05-31",
+            "physical": "181cm, 82kg",
+            "career": "청주우암초-청주중-청주고-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/65060_2023-03-20_103408.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "쿠에바스",
+            "backNum": "NO. 32",
+            "birth": "1990-10-14",
+            "physical": "188cm, 98kg",
+            "career": "베네수엘라 Universidad De Carabobo(대)-KT",
+            "bt": "우투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/69032_2022-02-23_160804.jpg"
+        },
+        {
+            "position": "투수",
+            "nameKr": "하준호",
+            "backNum": "NO. 28",
+            "birth": "1989-04-29",
+            "physical": "174cm, 78kg",
+            "career": "하단초-대동중-경남고-롯데-KT",
+            "bt": "좌투",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/78517_2023-03-20_104118.jpg"
+        }
     ],
     "catcher": [
-      {
-        "position": "포수",
-        "nameKr": "강현우",
-        "backNum": "NO. 55",
-        "birth": "2001-04-13",
-        "physical": "180cm, 90kg",
-        "career": "원종초(부천시리틀)-부천중-유신고-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/50066_2023-03-20_101753.jpg"
-      },
-      {
-        "position": "포수",
-        "nameKr": "김준태",
-        "backNum":"NO. 44",
-        "birth": "1994-07-31",
-        "physical": "175cm, 91kg",
-        "career": "양정초-개성중-경남고-(영남사이버대)-롯데-상무-롯데-KT",
-        "bt": "좌타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/62558_2023-03-20_103112.jpg"
-      },
-      {
-        "position": "포수",
-        "nameKr": "문상인",
-        "backNum": "NO. 33",
-        "birth": "1998-01-31",
-        "physical": "185cm, 79kg",
-        "career": "김해삼성초-개성중-경남고-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/67063_2023-03-20_103646.jpg"
-      },
-      {
-        "position": "포수",
-        "nameKr": "장성우",
-        "backNum": "NO. 22",
-        "birth": "1990-01-17",
-        "physical": "187cm, 100kg",
-        "career": "감천초-경남중-경남고-롯데-경찰-롯데-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/78548_2023-03-20_104131.jpg"
-      },
-      {
-        "position": "포수",
-        "nameKr": "조대현",
-        "backNum": "NO. 42",
-        "birth": "1999-08-06",
-        "physical": "183cm, 81kg",
-        "career": "길동초-매송중-유신고-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68089_2023-03-20_103830.jpg"
-      }
+        {
+            "position": "포수",
+            "nameKr": "강현우",
+            "backNum": "NO. 55",
+            "birth": "2001-04-13",
+            "physical": "180cm, 90kg",
+            "career": "원종초(부천시리틀)-부천중-유신고-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/50066_2023-03-20_101753.jpg"
+        },
+        {
+            "position": "포수",
+            "nameKr": "김준태",
+            "backNum": "NO. 44",
+            "birth": "1994-07-31",
+            "physical": "175cm, 91kg",
+            "career": "양정초-개성중-경남고-(영남사이버대)-롯데-상무-롯데-KT",
+            "bt": "좌타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/62558_2023-03-20_103112.jpg"
+        },
+        {
+            "position": "포수",
+            "nameKr": "문상인",
+            "backNum": "NO. 33",
+            "birth": "1998-01-31",
+            "physical": "185cm, 79kg",
+            "career": "김해삼성초-개성중-경남고-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/67063_2023-03-20_103646.jpg"
+        },
+        {
+            "position": "포수",
+            "nameKr": "장성우",
+            "backNum": "NO. 22",
+            "birth": "1990-01-17",
+            "physical": "187cm, 100kg",
+            "career": "감천초-경남중-경남고-롯데-경찰-롯데-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/78548_2023-03-20_104131.jpg"
+        },
+        {
+            "position": "포수",
+            "nameKr": "조대현",
+            "backNum": "NO. 42",
+            "birth": "1999-08-06",
+            "physical": "183cm, 81kg",
+            "career": "길동초-매송중-유신고-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68089_2023-03-20_103830.jpg"
+        }
     ],
     "infielder": [
-      {
-        "position": "내야수",
-        "nameKr": "강민성",
-        "backNum": "NO. 5",
-        "birth": "1999-12-08",
-        "physical": "180cm, 85kg",
-        "career": "대구옥산초-경상중-경북고-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/69064_2023-03-20_104009.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "강백호",
-        "backNum": "NO. 50",
-        "birth": "1999-07-29",
-        "physical": "184cm, 98kg",
-        "career": "부천북초-서울이수중-서울고-KT",
-        "bt": "좌타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68050_2023-03-20_103747.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "고명성",
-        "backNum": "NO. 9",
-        "birth": "1999-04-16",
-        "physical": "178cm, 68kg",
-        "career": "군산남초-군산남중-군산상고-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68069_2023-03-20_103816.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "김병희",
-        "backNum": "NO. 14",
-        "birth": "1990-12-06",
-        "physical": "180cm, 82kg",
-        "career": "창영초-신흥중-동산고-동국대-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64014_2023-03-20_103214.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "김상수",
-        "backNum": "NO. 7",
-        "birth": "1990-03-23",
-        "physical": "175cm, 68kg",
-        "career": "대구옥산초-경복중-경북고-삼성-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/79402_2023-03-20_104140.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "류현인",
-        "backNum": "NO. 36",
-        "birth": "2000-11-08",
-        "physical": "174cm, 80kg",
-        "career": "광주수창초-진흥중-진흥고-단국대-KT",
-        "bt": "좌타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/53036_2023-03-20_102646.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "문상준",
-        "backNum": "NO. 0",
-        "birth": "2001-03-14",
-        "physical": "183cm, 80kg",
-        "career": "가동초-휘문중-휘문고-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/50007_2023-03-20_100932.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "박경수",
-        "backNum": "NO. 6",
-        "birth": "1984-03-31",
-        "physical": "178cm, 80kg",
-        "career": "미성초-성남중-성남고-LG-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/73113_2023-03-20_104046.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "박민석",
-        "backNum": "NO. 98",
-        "birth": "2000-04-13",
-        "physical": "180cm, 77kg",
-        "career": "성동초-덕수중-장충고-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/69056_2023-03-20_103959.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "박병호",
-        "backNum": "NO. 52",
-        "birth": "1986-07-10",
-        "physical": "185cm, 107kg",
-        "career": "영일초(광명리틀)-영남중-성남고-LG-상무-LG-히어로즈-미네소타-넥센-키움-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/75125_2023-03-20_104059.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "손민석",
-        "backNum": "NO. 57",
-        "birth": "2004-06-21",
-        "physical": "177cm, 70kg",
-        "career": "감천초-개성중-경남고-KT",
-        "bt": "좌타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/53057_2023-03-20_102739.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "신본기",
-        "backNum": "NO. 56",
-        "birth": "1989-03-21",
-        "physical": "179cm, 88kg",
-        "career": "감천초-경남중-경남고-동아대-롯데-경찰-롯데-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/62556_2023-03-20_103100.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "양승혁",
-        "backNum": "NO. 2",
-        "birth": "1999-09-29",
-        "physical": "173cm, 68kg",
-        "career": "태랑초(남양주리틀)-청원중-서울고-KT",
-        "bt": "좌타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68002_2023-03-20_103712.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "오윤석",
-        "backNum": "NO. 4",
-        "birth": "1992-02-24",
-        "physical": "180cm, 87kg",
-        "career": "화중초-자양중-경기고-연세대-롯데-상무-롯데-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64504_2023-03-20_103305.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "이상호",
-        "backNum": "NO. 16",
-        "birth": "1989-02-05",
-        "physical": "180cm, 82kg",
-        "career": "대구옥산초-경운중-대구상원고-강릉영동대-NC-상무-NC-LG-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/60566_2023-03-20_103043.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "이호연",
-        "backNum": "NO. 34",
-        "birth": "1995-06-03",
-        "physical": "177cm, 87kg",
-        "career": "광주수창초-진흥중-광주제일고-성균관대-롯데-KT",
-        "bt": "좌타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68504_2023-06-02_103124.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "장준원",
-        "backNum": "NO. 3",
-        "birth": "1995-11-21",
-        "physical": "183cm, 77kg",
-        "career": "경운초(김해리틀)-개성중-경남고-LG-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64115_2023-03-20_103246.jpg"
-      },
-      {
-        "position": "내야수",
-        "nameKr": "황재균",
-        "backNum": "NO. 10",
-        "birth": "1987-07-28",
-        "physical": "183cm, 96kg",
-        "career": "사당초-서울이수중-경기고-현대-히어로즈-롯데-샌프란시스코-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/76313_2023-03-20_104107.jpg"
-      }
+        {
+            "position": "내야수",
+            "nameKr": "강민성",
+            "backNum": "NO. 5",
+            "birth": "1999-12-08",
+            "physical": "180cm, 85kg",
+            "career": "대구옥산초-경상중-경북고-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/69064_2023-03-20_104009.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "강백호",
+            "backNum": "NO. 50",
+            "birth": "1999-07-29",
+            "physical": "184cm, 98kg",
+            "career": "부천북초-서울이수중-서울고-KT",
+            "bt": "좌타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68050_2023-03-20_103747.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "고명성",
+            "backNum": "NO. 9",
+            "birth": "1999-04-16",
+            "physical": "178cm, 68kg",
+            "career": "군산남초-군산남중-군산상고-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68069_2023-03-20_103816.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "김병희",
+            "backNum": "NO. 14",
+            "birth": "1990-12-06",
+            "physical": "180cm, 82kg",
+            "career": "창영초-신흥중-동산고-동국대-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64014_2023-03-20_103214.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "김상수",
+            "backNum": "NO. 7",
+            "birth": "1990-03-23",
+            "physical": "175cm, 68kg",
+            "career": "대구옥산초-경복중-경북고-삼성-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/79402_2023-03-20_104140.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "류현인",
+            "backNum": "NO. 36",
+            "birth": "2000-11-08",
+            "physical": "174cm, 80kg",
+            "career": "광주수창초-진흥중-진흥고-단국대-KT",
+            "bt": "좌타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/53036_2023-03-20_102646.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "문상준",
+            "backNum": "NO. 0",
+            "birth": "2001-03-14",
+            "physical": "183cm, 80kg",
+            "career": "가동초-휘문중-휘문고-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/50007_2023-03-20_100932.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "박경수",
+            "backNum": "NO. 6",
+            "birth": "1984-03-31",
+            "physical": "178cm, 80kg",
+            "career": "미성초-성남중-성남고-LG-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/73113_2023-03-20_104046.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "박민석",
+            "backNum": "NO. 98",
+            "birth": "2000-04-13",
+            "physical": "180cm, 77kg",
+            "career": "성동초-덕수중-장충고-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/69056_2023-03-20_103959.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "박병호",
+            "backNum": "NO. 52",
+            "birth": "1986-07-10",
+            "physical": "185cm, 107kg",
+            "career": "영일초(광명리틀)-영남중-성남고-LG-상무-LG-히어로즈-미네소타-넥센-키움-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/75125_2023-03-20_104059.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "손민석",
+            "backNum": "NO. 57",
+            "birth": "2004-06-21",
+            "physical": "177cm, 70kg",
+            "career": "감천초-개성중-경남고-KT",
+            "bt": "좌타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/53057_2023-03-20_102739.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "신본기",
+            "backNum": "NO. 56",
+            "birth": "1989-03-21",
+            "physical": "179cm, 88kg",
+            "career": "감천초-경남중-경남고-동아대-롯데-경찰-롯데-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/62556_2023-03-20_103100.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "양승혁",
+            "backNum": "NO. 2",
+            "birth": "1999-09-29",
+            "physical": "173cm, 68kg",
+            "career": "태랑초(남양주리틀)-청원중-서울고-KT",
+            "bt": "좌타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68002_2023-03-20_103712.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "오윤석",
+            "backNum": "NO. 4",
+            "birth": "1992-02-24",
+            "physical": "180cm, 87kg",
+            "career": "화중초-자양중-경기고-연세대-롯데-상무-롯데-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64504_2023-03-20_103305.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "이상호",
+            "backNum": "NO. 16",
+            "birth": "1989-02-05",
+            "physical": "180cm, 82kg",
+            "career": "대구옥산초-경운중-대구상원고-강릉영동대-NC-상무-NC-LG-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/60566_2023-03-20_103043.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "이호연",
+            "backNum": "NO. 34",
+            "birth": "1995-06-03",
+            "physical": "177cm, 87kg",
+            "career": "광주수창초-진흥중-광주제일고-성균관대-롯데-KT",
+            "bt": "좌타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/68504_2023-06-02_103124.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "장준원",
+            "backNum": "NO. 3",
+            "birth": "1995-11-21",
+            "physical": "183cm, 77kg",
+            "career": "경운초(김해리틀)-개성중-경남고-LG-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64115_2023-03-20_103246.jpg"
+        },
+        {
+            "position": "내야수",
+            "nameKr": "황재균",
+            "backNum": "NO. 10",
+            "birth": "1987-07-28",
+            "physical": "183cm, 96kg",
+            "career": "사당초-서울이수중-경기고-현대-히어로즈-롯데-샌프란시스코-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/76313_2023-03-20_104107.jpg"
+        }
     ],
     "outfielder": [
-      {
-        "position": "외야수",
-        "nameKr": "김건형",
-        "backNum": "NO. 40",
-        "birth": "1996-07-12",
-        "physical": "182cm, 83kg",
-        "career": "먼우금초-Lesbois(중)-Timberline(고)-Boise State(대)-KT",
-        "bt": "좌타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/51005_2023-06-02_103113.jpg"
-      },
-      {
-        "position": "외야수",
-        "nameKr": "김민혁",
-        "backNum": "NO. 53",
-        "birth": "1995-11-21",
-        "physical": "181cm, 71kg",
-        "career": "광주서석초-배재중-배재고-KT-상무-KT",
-        "bt": "좌타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64004_2023-03-20_103135.jpg"
-      },
-      {
-        "position": "외야수",
-        "nameKr": "김병준",
-        "backNum": "NO. 97",
-        "birth": "2003-07-03",
-        "physical": "175cm, 80kg",
-        "career": "창촌초(안산리틀)-안산중앙중-유신고-KT",
-        "bt": "좌타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/52002_2023-03-20_102050.jpg"
-      },
-      {
-        "position": "외야수",
-        "nameKr": "문상철",
-        "backNum": "NO. 24",
-        "birth": "1991-04-06",
-        "physical": "184cm, 85kg",
-        "career": "중대초-잠신중-배명고-고려대-KT-상무-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64007_2023-03-20_103156.jpg"
-      },
-      {
-        "position": "외야수",
-        "nameKr": "배정대",
-        "backNum": "NO. 27",
-        "birth": "1995-06-12",
-        "physical": "185cm, 80kg",
-        "career": "도신초-성남중-성남고-(디지털문예대)-LG-KT-경찰-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64166_2023-03-20_103256.jpg"
-      },
-      {
-        "position": "외야수",
-        "nameKr": "송민섭",
-        "backNum": "NO. 12",
-        "birth": "1991-08-02",
-        "physical": "177cm, 80kg",
-        "career": "청파초(안산리틀)-선린중-선린인터넷고-단국대-KT-상무-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64012_2023-03-20_103205.jpg"
-      },
-      {
-        "position": "외야수",
-        "nameKr": "안치영",
-        "backNum": "NO. 8",
-        "birth": "1998-05-29",
-        "physical": "176cm, 72kg",
-        "career": "중동초(원미구리틀)-천안북중-북일고-KT",
-        "bt": "좌타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/67006_2023-03-20_103600.jpg"
-      },
-      {
-        "position": "외야수",
-        "nameKr": "알포드",
-        "backNum": "NO. 25",
-        "birth": "1994-07-20",
-        "physical": "185cm, 95kg",
-        "career": "미국 Mississippi(대)-KT",
-        "bt": "우타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/52009_2023-03-20_102226.jpg"
-      },
-      {
-        "position": "외야수",
-        "nameKr": "이시원",
-        "backNum": "NO. 13",
-        "birth": "1996-07-24",
-        "physical": "178cm, 72kg",
-        "career": "본리초-경운중-대구상원고-한화-KT",
-        "bt": "좌타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/66702_2023-03-20_103526.jpg"
-      },
-      {
-        "position": "외야수",
-        "nameKr": "정준영",
-        "backNum": "NO. 58",
-        "birth": "2004-01-26",
-        "physical": "173cm, 73kg",
-        "career": "도신초-강남중-장충고-KT",
-        "bt": "좌타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/53058_2023-03-20_103007.jpg"
-      },
-      {
-        "position": "외야수",
-        "nameKr": "조용호",
-        "backNum": "NO. 23",
-        "birth": "1989-09-09",
-        "physical": "170cm, 75kg",
-        "career": "성동초-잠신중-야탑고-단국대-SK-KT",
-        "bt": "좌타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64868_2023-03-20_103328.jpg"
-      },
-      {
-        "position": "외야수",
-        "nameKr": "최성민",
-        "backNum": "NO. 69",
-        "birth": "2002-07-05",
-        "physical": "179cm, 84kg",
-        "career": "송정동초-무등중-광주동성고-KT",
-        "bt": "좌타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/51007_2023-03-20_102001.jpg"
-      },
-      {
-        "position": "외야수",
-        "nameKr": "홍현빈",
-        "backNum": "NO. 31",
-        "birth": "1997-08-29",
-        "physical": "174cm, 70kg",
-        "career": "수원신곡초-매송중-유신고-KT-상무-KT",
-        "bt": "좌타",
-        "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/67005_2023-03-20_103548.jpg"
-      }
+        {
+            "position": "외야수",
+            "nameKr": "김건형",
+            "backNum": "NO. 40",
+            "birth": "1996-07-12",
+            "physical": "182cm, 83kg",
+            "career": "먼우금초-Lesbois(중)-Timberline(고)-Boise State(대)-KT",
+            "bt": "좌타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/51005_2023-06-02_103113.jpg"
+        },
+        {
+            "position": "외야수",
+            "nameKr": "김민혁",
+            "backNum": "NO. 53",
+            "birth": "1995-11-21",
+            "physical": "181cm, 71kg",
+            "career": "광주서석초-배재중-배재고-KT-상무-KT",
+            "bt": "좌타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64004_2023-03-20_103135.jpg"
+        },
+        {
+            "position": "외야수",
+            "nameKr": "김병준",
+            "backNum": "NO. 97",
+            "birth": "2003-07-03",
+            "physical": "175cm, 80kg",
+            "career": "창촌초(안산리틀)-안산중앙중-유신고-KT",
+            "bt": "좌타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/52002_2023-03-20_102050.jpg"
+        },
+        {
+            "position": "외야수",
+            "nameKr": "문상철",
+            "backNum": "NO. 24",
+            "birth": "1991-04-06",
+            "physical": "184cm, 85kg",
+            "career": "중대초-잠신중-배명고-고려대-KT-상무-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64007_2023-03-20_103156.jpg"
+        },
+        {
+            "position": "외야수",
+            "nameKr": "배정대",
+            "backNum": "NO. 27",
+            "birth": "1995-06-12",
+            "physical": "185cm, 80kg",
+            "career": "도신초-성남중-성남고-(디지털문예대)-LG-KT-경찰-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64166_2023-03-20_103256.jpg"
+        },
+        {
+            "position": "외야수",
+            "nameKr": "송민섭",
+            "backNum": "NO. 12",
+            "birth": "1991-08-02",
+            "physical": "177cm, 80kg",
+            "career": "청파초(안산리틀)-선린중-선린인터넷고-단국대-KT-상무-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64012_2023-03-20_103205.jpg"
+        },
+        {
+            "position": "외야수",
+            "nameKr": "안치영",
+            "backNum": "NO. 8",
+            "birth": "1998-05-29",
+            "physical": "176cm, 72kg",
+            "career": "중동초(원미구리틀)-천안북중-북일고-KT",
+            "bt": "좌타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/67006_2023-03-20_103600.jpg"
+        },
+        {
+            "position": "외야수",
+            "nameKr": "알포드",
+            "backNum": "NO. 25",
+            "birth": "1994-07-20",
+            "physical": "185cm, 95kg",
+            "career": "미국 Mississippi(대)-KT",
+            "bt": "우타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/52009_2023-03-20_102226.jpg"
+        },
+        {
+            "position": "외야수",
+            "nameKr": "이시원",
+            "backNum": "NO. 13",
+            "birth": "1996-07-24",
+            "physical": "178cm, 72kg",
+            "career": "본리초-경운중-대구상원고-한화-KT",
+            "bt": "좌타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/66702_2023-03-20_103526.jpg"
+        },
+        {
+            "position": "외야수",
+            "nameKr": "정준영",
+            "backNum": "NO. 58",
+            "birth": "2004-01-26",
+            "physical": "173cm, 73kg",
+            "career": "도신초-강남중-장충고-KT",
+            "bt": "좌타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/53058_2023-03-20_103007.jpg"
+        },
+        {
+            "position": "외야수",
+            "nameKr": "조용호",
+            "backNum": "NO. 23",
+            "birth": "1989-09-09",
+            "physical": "170cm, 75kg",
+            "career": "성동초-잠신중-야탑고-단국대-SK-KT",
+            "bt": "좌타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/64868_2023-03-20_103328.jpg"
+        },
+        {
+            "position": "외야수",
+            "nameKr": "최성민",
+            "backNum": "NO. 69",
+            "birth": "2002-07-05",
+            "physical": "179cm, 84kg",
+            "career": "송정동초-무등중-광주동성고-KT",
+            "bt": "좌타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/51007_2023-03-20_102001.jpg"
+        },
+        {
+            "position": "외야수",
+            "nameKr": "홍현빈",
+            "backNum": "NO. 31",
+            "birth": "1997-08-29",
+            "physical": "174cm, 70kg",
+            "career": "수원신곡초-매송중-유신고-KT-상무-KT",
+            "bt": "좌타",
+            "img": "https://wizzap.ktwiz.co.kr/files/playerImg/ktImg/67005_2023-03-20_103548.jpg"
+        }
     ]
-  }
+}

--- a/playerList.js
+++ b/playerList.js
@@ -1,14 +1,14 @@
-import playerList from "./playerData.json" assert{type:"json"};
+import playerList from "./playerData.json" assert{type: "json"};
 // console.log(playerList);
 drawPitcher();
 drawCatcher();
 drawInfielder();
 drawOutfielder();
 
-function drawPitcher(){
+function drawPitcher() {
     let pitcherUl = document.getElementById("pitcherList");
-    
-    for(let i = 0; i < playerList.pitcher.length; i++){
+
+    for (let i = 0; i < playerList.pitcher.length; i++) {
         //html 요소 생성
         let playerLi = document.createElement("li");
         let playerArticle = document.createElement("article");
@@ -34,10 +34,10 @@ function drawPitcher(){
     }
 }
 
-function drawCatcher(){
+function drawCatcher() {
     let catcherUl = document.getElementById("catcherList");
-    
-    for(let i = 0; i < playerList.catcher.length; i++){
+
+    for (let i = 0; i < playerList.catcher.length; i++) {
         //html 요소 생성
         let playerLi = document.createElement("li");
         let playerArticle = document.createElement("article");
@@ -63,10 +63,10 @@ function drawCatcher(){
     }
 }
 
-function drawInfielder(){
+function drawInfielder() {
     let infielderUl = document.getElementById("infielderList");
-    
-    for(let i = 0; i < playerList.infielder.length; i++){
+
+    for (let i = 0; i < playerList.infielder.length; i++) {
         //html 요소 생성
         let playerLi = document.createElement("li");
         let playerArticle = document.createElement("article");
@@ -92,10 +92,10 @@ function drawInfielder(){
     }
 }
 
-function drawOutfielder(){
+function drawOutfielder() {
     let outfielderUl = document.getElementById("outfielderList");
-    
-    for(let i = 0; i < playerList.outfielder.length; i++){
+
+    for (let i = 0; i < playerList.outfielder.length; i++) {
         //html 요소 생성
         let playerLi = document.createElement("li");
         let playerArticle = document.createElement("article");

--- a/playerList.js
+++ b/playerList.js
@@ -1,9 +1,9 @@
-import playerList from "./playerData.json" assert{type: "json"};
-// console.log(playerList);
-drawPitcher();
-drawCatcher();
-drawInfielder();
-drawOutfielder();
+window.onload = function() {
+    drawPitcher();
+    drawCatcher();
+    drawInfielder();
+    drawOutfielder();
+}
 
 function drawPitcher() {
     let pitcherUl = document.getElementById("pitcherList");


### PR DESCRIPTION
## 내용
- 수정: 선수 / 연혁 데이터를 로컬 환경에서 읽을 수 없는 문제 수정 (CORS)
  - 과제 요구 조건 중 로컬 환경에서 `index.html`을 직접 실행한다는 내용 있음
  - CORS 정책에 의해 로컬에 있는 파일을 ES6 파일을 모듈로 읽어올 수 없음
  - HTML `<head>` 태그에서 로드되는 스크립트 파일이 DOM을 수정할 수 있도록 `window.onload`에 콜백 함수 등록
- 수정: Flex 속성을 사용하여 연혁 데이터를 좌/우로 배치하고 구분 테두리를 추가
![완성본](https://github.com/sulebread/Web-ktwiz/assets/3435833/3ca789a9-7496-41c1-91e3-beb4592da845)

## 기타 작업
- 코드 서식 포맷팅
- 사용되지 않는 DOM 객체 생성 코드(`historyDesc`) 제거
- 불필요한 HTML 태그(`test` 클래스) 제거